### PR TITLE
Fix tests for non-English locale (month name)

### DIFF
--- a/core/src/test/scala/zio/web/http/middleware/HttpMiddlewareSpec.scala
+++ b/core/src/test/scala/zio/web/http/middleware/HttpMiddlewareSpec.scala
@@ -17,9 +17,11 @@ import java.io.{ ByteArrayOutputStream, File }
 import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.nio.file.Paths
+import java.util.Locale
 
 object HttpMiddlewareSpec extends DefaultRunnableSpec {
-
+  Locale.setDefault(new Locale("en", "US"));
+  
   def spec =
     suite("HttpMiddleware")(loggingSpec, basicAuthSpec)
 


### PR DESCRIPTION
Quick fix for unit tests failing on non-english locale